### PR TITLE
support opencl 1.2 for pocl.

### DIFF
--- a/0.bindings-src/2-0-package.lisp
+++ b/0.bindings-src/2-0-package.lisp
@@ -146,17 +146,20 @@
      (lispify "device_mem_cache_type")
      (lispify "device_local_mem_type")
      (lispify "device_exec_capabilities")
+     #+opencl-2.0
      (lispify "device_svm_capabilities")
      (lispify "command_queue_properties")
      (lispify "device_partition_property")
      (lispify "device_affinity_domain")
      (lispify "context_properties")
      (lispify "context_info")
+     #+opencl-2.0
      (lispify "queue_properties")
      (lispify "command_queue_info")
      (lispify "channel_order")
      (lispify "channel_type")
      (lispify "mem_flags")
+     #+opencl-2.0
      (lispify "svm_mem_flags")
      (lispify "mem_object_type")
      (lispify "mem_info")
@@ -167,7 +170,9 @@
      (lispify "filter_mode")
      (lispify "sampler_info")
      (lispify "map_flags")
+     #+opencl-2.0
      (lispify "pipe_properties")
+     #+opencl-2.0
      (lispify "pipe_info")
      (lispify "program_info")
      (lispify "program_build_info")
@@ -184,7 +189,9 @@
      (lispify "event_info")
      (lispify "command_type")
      (lispify "profiling_info")
+     #+opencl-2.0
      (lispify "sampler_properties")
+     #+opencl-2.0
      (lispify "kernel_exec_info"))
   #.(list
      :export

--- a/0.bindings-src/2-4-grovel-cl-enum.lisp
+++ b/0.bindings-src/2-4-grovel-cl-enum.lisp
@@ -75,7 +75,7 @@
               (#.(lispify-k-pair "CL_INVALID_DEVICE_PARTITION_COUNT"))
               (#.(lispify-k-pair "CL_INVALID_PIPE_SIZE"))
               (#.(lispify-k-pair "CL_INVALID_DEVICE_QUEUE"))
-              #+opencl-2.0
+              ;; extension
               (#.(lispify-k-pair "CL_PLATFORM_NOT_FOUND_KHR")))
 
 (constantenum (#.(lispify "platform_info") :base-type #.(lispify "__platform_info"))
@@ -84,9 +84,8 @@
               (#.(lispify-k-pair "CL_PLATFORM_NAME"))
               (#.(lispify-k-pair "CL_PLATFORM_VENDOR"))
               (#.(lispify-k-pair "CL_PLATFORM_EXTENSIONS"))
-              #+opencl-2.0
-              (#.(lispify-k-pair "CL_PLATFORM_ICD_SUFFIX_KHR"))
-              )
+              ;; extension
+              (#.(lispify-k-pair "CL_PLATFORM_ICD_SUFFIX_KHR")))
 
 (bitfield (#.(lispify "device_type") :base-type #.(lispify "__device_type"))
           (#.(lispify-k-pair "CL_DEVICE_TYPE_DEFAULT"))
@@ -235,6 +234,7 @@
           #+opencl-2.0
           (#.(lispify-k-pair "CL_QUEUE_ON_DEVICE_DEFAULT")))
 
+#+opencl-2.0
 (constantenum (#.(lispify "queue_properties") :base-type #.(lispify "__queue_properties"))
               (#.(lispify-k-pair "CL_QUEUE_PROPERTIES"))
               (#.(lispify-k-pair "CL_QUEUE_SIZE")))
@@ -264,6 +264,7 @@
           (#.(lispify-k-pair "CL_DEVICE_AFFINITY_DOMAIN_L1_CACHE"))
           (#.(lispify-k-pair "CL_DEVICE_AFFINITY_DOMAIN_NEXT_PARTITIONABLE")))
 
+#+opencl-2.0
 (bitfield (#.(lispify "device_svm_capabilities") :base-type #.(lispify "__device_svm_capabilities"))
           (#.(lispify-k-pair "CL_DEVICE_SVM_COARSE_GRAIN_BUFFER"))
           (#.(lispify-k-pair "CL_DEVICE_SVM_FINE_GRAIN_BUFFER"))
@@ -293,6 +294,7 @@
           (#.(lispify-k-pair "CL_MEM_KERNEL_READ_AND_WRITE")))
 
 ;; FIXME : duplicated --- cl_mem_flags
+#+opencl-2.0
 (bitfield (#.(lispify "svm_mem_flags") :base-type #.(lispify "__svm_mem_flags"))
           (#.(lispify-k-pair "CL_MEM_READ_WRITE"))
           (#.(lispify-k-pair "CL_MEM_WRITE_ONLY"))
@@ -391,10 +393,12 @@
               (#.(lispify-k-pair "CL_IMAGE_NUM_MIP_LEVELS"))
               (#.(lispify-k-pair "CL_IMAGE_NUM_SAMPLES")))
 
+#+opencl-2.0
 (constantenum (#.(lispify "pipe_info") :base-type #.(lispify "__pipe_info"))
               (#.(lispify-k-pair "CL_PIPE_PACKET_SIZE"))
               (#.(lispify-k-pair "CL_PIPE_MAX_PACKETS")))
 
+#+opencl-2.0
 (constantenum (#.(lispify "pipe_properties") :base-type #.(lispify "__pipe_properties")))
 
 
@@ -421,6 +425,7 @@
               ;; (#.(lispify-k-pair "CL_SAMPLER_LOD_MAX"))
               )
 
+#+opencl-2.0
 (constantenum (#.(lispify "sampler_properties") :base-type #.(lispify "__sampler_properties"))
               (#.(lispify-k-pair "CL_SAMPLER_NORMALIZED_COORDS"))
               (#.(lispify-k-pair "CL_SAMPLER_ADDRESSING_MODE"))

--- a/0.bindings-src/2-4-grovel-cl.lisp
+++ b/0.bindings-src/2-4-grovel-cl.lisp
@@ -37,17 +37,20 @@
 (ctype #.(lispify "__device_mem_cache_type") "cl_device_mem_cache_type")
 (ctype #.(lispify "__device_local_mem_type") "cl_device_local_mem_type")
 (ctype #.(lispify "__device_exec_capabilities") "cl_device_exec_capabilities")
+#+opencl-2.0
 (ctype #.(lispify "__device_svm_capabilities") "cl_device_svm_capabilities")
 (ctype #.(lispify "__command_queue_properties") "cl_command_queue_properties")
 (ctype #.(lispify "__device_partition_property") "cl_device_partition_property")
 (ctype #.(lispify "__device_affinity_domain") "cl_device_affinity_domain")
 (ctype #.(lispify "__context_properties") "cl_context_properties")
 (ctype #.(lispify "__context_info") "cl_context_info")
+#+opencl-2.0
 (ctype #.(lispify "__queue_properties") "cl_queue_properties")
 (ctype #.(lispify "__command_queue_info") "cl_command_queue_info")
 (ctype #.(lispify "__channel_order") "cl_channel_order")
 (ctype #.(lispify "__channel_type") "cl_channel_type")
 (ctype #.(lispify "__mem_flags") "cl_mem_flags")
+#+opencl-2.0
 (ctype #.(lispify "__svm_mem_flags") "cl_svm_mem_flags")
 (ctype #.(lispify "__mem_object_type") "cl_mem_object_type")
 (ctype #.(lispify "__mem_info") "cl_mem_info")
@@ -58,7 +61,9 @@
 (ctype #.(lispify "__filter_mode") "cl_filter_mode")
 (ctype #.(lispify "__sampler_info") "cl_sampler_info")
 (ctype #.(lispify "__map_flags") "cl_map_flags")
+#+opencl-2.0
 (ctype #.(lispify "__pipe_properties") "cl_pipe_properties")
+#+opencl-2.0
 (ctype #.(lispify "__pipe_info") "cl_pipe_info")
 (ctype #.(lispify "__program_info") "cl_program_info")
 (ctype #.(lispify "__program_build_info") "cl_program_build_info")
@@ -75,6 +80,8 @@
 (ctype #.(lispify "__event_info") "cl_event_info")
 (ctype #.(lispify "__command_type") "cl_command_type")
 (ctype #.(lispify "__profiling_info") "cl_profiling_info")
+#+opencl-2.0
 (ctype #.(lispify "__sampler_properties") "cl_sampler_properties")
+#+opencl-2.0
 (ctype #.(lispify "__kernel_exec_info") "cl_kernel_exec_info")
 

--- a/2.host-src/0package.lisp
+++ b/2.host-src/0package.lisp
@@ -33,6 +33,8 @@ Copyright (c) 2015 Masataro Asai (guicho2.71828@gmail.com)
    #:get-supported-image-formats
    ;; setter api
    #:set-kernel-arg
+   #+opencl-2.0
+   #:set-kernel-exec-info
    ;; create api
    #:create-context
    #:create-context-from-type
@@ -40,6 +42,7 @@ Copyright (c) 2015 Masataro Asai (guicho2.71828@gmail.com)
    #:create-command-queue-with-properties
    #:create-buffer
    #:create-image
+   #+opencl-2.0
    #:create-pipe
    #:create-sampler
    #:create-sampler-with-properties

--- a/2.host-src/4getter-api-definitions.lisp
+++ b/2.host-src/4getter-api-definitions.lisp
@@ -9,6 +9,7 @@
   (:queue-context         %ocl:context)
   (:queue-device          %ocl:device-id)
   (:queue-reference-count %ocl:uint)
+  #+opencl-2.0
   (:queue-properties      %ocl:command-queue-properties)
   (:queue-size            %ocl:uint))
 
@@ -101,10 +102,12 @@
   (:device-queue-on-device-max-size             %ocl:uint)
   (:device-queue-on-device-preferred-size       %ocl:uint)
   (:device-queue-on-device-properties           %ocl:command-queue-properties)
+  #+opencl-2.0
   (:device-queue-on-host-properties             %ocl:command-queue-properties)
   (:device-queue-properties                     %ocl:command-queue-properties)
   (:device-reference-count                      %ocl:uint)
   (:device-single-fp-config                     %ocl:device-fp-config)
+  #+opencl-2.0
   (:device-svm-capabilities                     %ocl:device-svm-capabilities)
   (:device-type                                 %ocl:device-type)
   (:device-vendor                               :string)

--- a/2.host-src/5setter-api.lisp
+++ b/2.host-src/5setter-api.lisp
@@ -10,6 +10,7 @@
 ;;   (:kernel-exec-info-svm-ptrs (:pointer :void) :array t)
 ;;   (:kernel-exec-info-svm-fine-grain-system %ocl:bool))
 
+#+opencl-2.0
 (defun set-kernel-exec-info (kernel param-name value)
   (ecase param-name
     (:kernel-exec-info-svm-ptrs

--- a/2.host-src/7create-apis.lisp
+++ b/2.host-src/7create-apis.lisp
@@ -60,6 +60,7 @@ Properties should be a list of :out-of-order-exec-mode-enable and :profiling-ena
 
 ;;;; Pipes
 
+#+opencl-2.0
 (defun create-pipe #.`(context flags packet-size max-packets &rest properties
                                &key ,@(enum-keywords-as-symbols '%ocl:pipe-properties))
   #+opencl-2.0


### PR DESCRIPTION
support opencl 1.2 for pocl.

`(asdf:test-system :eazy-opencl)` result.

```
Running test suite EAZY-OPENCL
 Running test SETUP .
OpenCL Test: querying PLATFORM-EXTENSIONS to PLATFORM (140737152780544)
OpenCL Info:  "cl_khr_icd" for query PLATFORM-EXTENSIONS to PLATFORM (140737152780544).
OpenCL Test: querying PLATFORM-ICD-SUFFIX-KHR to PLATFORM (140737152780544)
OpenCL Info:  "POCL" for query PLATFORM-ICD-SUFFIX-KHR to PLATFORM (140737152780544).
OpenCL Test: querying PLATFORM-NAME to PLATFORM (140737152780544)
OpenCL Info:  "Portable Computing Language" for query PLATFORM-NAME to PLATFORM (140737152780544).
OpenCL Test: querying PLATFORM-PROFILE to PLATFORM (140737152780544)
OpenCL Info:  "FULL_PROFILE" for query PLATFORM-PROFILE to PLATFORM (140737152780544).
OpenCL Test: querying PLATFORM-VENDOR to PLATFORM (140737152780544)
OpenCL Info:  "The pocl project" for query PLATFORM-VENDOR to PLATFORM (140737152780544).
OpenCL Test: querying PLATFORM-VERSION to PLATFORM (140737152780544)
OpenCL Info:  "OpenCL 1.2 pocl 0.10" for query PLATFORM-VERSION to PLATFORM (140737152780544).
list of device ids with platform-id 140737152780544 and type (DEVICE-TYPE-ACCELERATOR):
OpenCL Success: NIL for (GET-DEVICE-IDS PID (LIST TYPE)) (args: 140737152780544
                (:DEVICE-TYPE-ACCELERATOR) )
OpenCL Error:   :INVALID-DEVICE-QUEUE for
                (CREATE-CONTEXT-FROM-TYPE TYPE CONTEXT-PLATFORM PID) (args:
                :DEVICE-TYPE-ACCELERATOR :CONTEXT-PLATFORM 140737152780544 )
list of device ids with platform-id 140737152780544 and type (DEVICE-TYPE-ALL):
OpenCL Success: (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                    :VALUE 140737018676832))
                for (GET-DEVICE-IDS PID (LIST TYPE)) (args: 140737152780544
                (:DEVICE-TYPE-ALL) )
OpenCL Test: querying DEVICE-ADDRESS-BITS to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                        :VALUE 140737018676832))
OpenCL Info:  64 for query DEVICE-ADDRESS-BITS to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                             :VALUE 140737018676832)).
OpenCL Test: querying DEVICE-AVAILABLE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                     :VALUE 140737018676832))
OpenCL Info:  T for query DEVICE-AVAILABLE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                         :VALUE 140737018676832)).
OpenCL Test: querying DEVICE-BUILT-IN-KERNELS to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                            :VALUE 140737018676832))
OpenCL Info:  "" for query DEVICE-BUILT-IN-KERNELS to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                 :VALUE 140737018676832)).
OpenCL Test: querying DEVICE-COMPILER-AVAILABLE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                              :VALUE 140737018676832))
OpenCL Info:  T for query DEVICE-COMPILER-AVAILABLE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                  :VALUE 140737018676832)).
OpenCL Test: querying DEVICE-DOUBLE-FP-CONFIG to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                            :VALUE 140737018676832))
OpenCL Info:  (:FP-INF-NAN :FP-ROUND-TO-NEAREST) for query DEVICE-DOUBLE-FP-CONFIG to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                                                 :VALUE 140737018676832)).
OpenCL Test: querying DEVICE-ENDIAN-LITTLE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                         :VALUE 140737018676832))
OpenCL Info:  T for query DEVICE-ENDIAN-LITTLE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                             :VALUE 140737018676832)).
OpenCL Test: querying DEVICE-ERROR-CORRECTION-SUPPORT to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                    :VALUE 140737018676832))
OpenCL Info:  NIL for query DEVICE-ERROR-CORRECTION-SUPPORT to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                          :VALUE 140737018676832)).
OpenCL Test: querying DEVICE-EXECUTION-CAPABILITIES to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                  :VALUE 140737018676832))
OpenCL Info:  (:EXEC-KERNEL :EXEC-NATIVE-KERNEL) for query DEVICE-EXECUTION-CAPABILITIES to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                                                       :VALUE 140737018676832)).
OpenCL Test: querying DEVICE-EXTENSIONS to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                      :VALUE 140737018676832))
OpenCL Info:  "cl_khr_fp64 cl_khr_byte_addressable_store" for query DEVICE-EXTENSIONS to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                                                    :VALUE 140737018676832)).
OpenCL Test: querying DEVICE-GLOBAL-MEM-CACHE-SIZE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                 :VALUE 140737018676832))
OpenCL Info:  0 for query DEVICE-GLOBAL-MEM-CACHE-SIZE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                     :VALUE 140737018676832)).
OpenCL Test: querying DEVICE-GLOBAL-MEM-CACHE-TYPE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                 :VALUE 140737018676832))
OpenCL Info:  :NONE for query DEVICE-GLOBAL-MEM-CACHE-TYPE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                         :VALUE 140737018676832)).
OpenCL Test: querying DEVICE-GLOBAL-MEM-CACHELINE-SIZE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                     :VALUE 140737018676832))
OpenCL Info:  0 for query DEVICE-GLOBAL-MEM-CACHELINE-SIZE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                         :VALUE 140737018676832)).
OpenCL Test: querying DEVICE-GLOBAL-MEM-SIZE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                           :VALUE 140737018676832))
OpenCL Info:  8264417280 for query DEVICE-GLOBAL-MEM-SIZE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                        :VALUE 140737018676832)).
OpenCL Test: querying DEVICE-GLOBAL-VARIABLE-PREFERRED-TOTAL-SIZE to DEVICE (#S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID
                                                                                :VALUE 140737018676832))Xff
 Running test HELLOWORLD 
OpenCL Error:   :INVALID-DEVICE-QUEUE for
                (CREATE-CONTEXT-FROM-TYPE TYPE CONTEXT-PLATFORM PID) (args:
                :DEVICE-TYPE-ACCELERATOR :CONTEXT-PLATFORM 140737152780544 )ss
OpenCL Success: #S(EAZY-OPENCL.BINDINGS:BOXED-CONTEXT :VALUE 140737018601872)
                for (CREATE-CONTEXT-FROM-TYPE TYPE CONTEXT-PLATFORM PID) (args:
                :DEVICE-TYPE-ALL :CONTEXT-PLATFORM 140737152780544 ).
WARNING:
   This interface is deprecated in opencl 2.0! Use create-command-queue-with-properties.

OpenCL Success: #S(EAZY-OPENCL.BINDINGS:BOXED-COMMAND-QUEUE
                   :VALUE 140737018601344)
                for (CREATE-COMMAND-QUEUE CTX DID) (args:
                #S(EAZY-OPENCL.BINDINGS:BOXED-CONTEXT :VALUE 140737018601872)
                #S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID :VALUE 140737018676832)
                )
OpenCL Test: querying MEM-ASSOCIATED-MEMOBJECT to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                             :VALUE 140737018599232))
OpenCL Info:  #S(EAZY-OPENCL.BINDINGS:BOXED-MEM :VALUE 0) for query MEM-ASSOCIATED-MEMOBJECT to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                                                                           :VALUE 140737018599232)).
OpenCL Test: querying MEM-CONTEXT to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                :VALUE 140737018599232))
OpenCL Info:  #S(EAZY-OPENCL.BINDINGS:BOXED-CONTEXT :VALUE 140737018601872) for query MEM-CONTEXT to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                                                                                :VALUE 140737018599232)).
OpenCL Test: querying MEM-FLAGS to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                              :VALUE 140737018599232))
OpenCL Info:  (:MEM-WRITE-ONLY :MEM-USE-HOST-PTR) for query MEM-FLAGS to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                                                    :VALUE 140737018599232)).
OpenCL Test: querying MEM-HOST-PTR to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                 :VALUE 140737018599232))
OpenCL Info:  #.(SB-SYS:INT-SAP #X7FFFF0627FE8) for query MEM-HOST-PTR to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                                                     :VALUE 140737018599232)).
OpenCL Test: querying MEM-MAP-COUNT to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                  :VALUE 140737018599232))
OpenCL Info:  0 for query MEM-MAP-COUNT to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                      :VALUE 140737018599232)).
OpenCL Test: querying MEM-OFFSET to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                               :VALUE 140737018599232))
OpenCL Info:  0 for query MEM-OFFSET to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                   :VALUE 140737018599232)).
OpenCL Test: querying MEM-REFERENCE-COUNT to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                        :VALUE 140737018599232))
OpenCL Info:  1 for query MEM-REFERENCE-COUNT to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                            :VALUE 140737018599232)).
OpenCL Test: querying MEM-SIZE to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                             :VALUE 140737018599232))
OpenCL Info:  13 for query MEM-SIZE to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                  :VALUE 140737018599232)).
OpenCL Test: querying MEM-TYPE to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                             :VALUE 140737018599232))
OpenCL Info:  :MEM-OBJECT-BUFFER for query MEM-TYPE to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                                  :VALUE 140737018599232)).
OpenCL Test: querying MEM-USES-SVM-POINTER to BUFFER (#S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER
                                                         :VALUE 140737018599232))Xf
 Running test HELLOWORLD-FROM-FILE 
OpenCL Error:   :INVALID-DEVICE-QUEUE for
                (CREATE-CONTEXT-FROM-TYPE TYPE CONTEXT-PLATFORM PID) (args:
                :DEVICE-TYPE-ACCELERATOR :CONTEXT-PLATFORM 140737152780544 )ss
OpenCL Success: #S(EAZY-OPENCL.BINDINGS:BOXED-CONTEXT :VALUE 140737019925296)
                for (CREATE-CONTEXT-FROM-TYPE TYPE CONTEXT-PLATFORM PID) (args:
                :DEVICE-TYPE-ALL :CONTEXT-PLATFORM 140737152780544 ).
WARNING:
   This interface is deprecated in opencl 2.0! Use create-command-queue-with-properties.

OpenCL Success: #S(EAZY-OPENCL.BINDINGS:BOXED-COMMAND-QUEUE
                   :VALUE 140737026928464)
                for (CREATE-COMMAND-QUEUE CTX DID) (args:
                #S(EAZY-OPENCL.BINDINGS:BOXED-CONTEXT :VALUE 140737019925296)
                #S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID :VALUE 140737018676832)
                )
OpenCL Success: :SUCCESS for
                (ENQUEUE-ND-RANGE-KERNEL CQ KERNEL 1 (NULL-POINTER)
                                         GLOBAL-WORK-SIZE (NULL-POINTER) 0
                                         (NULL-POINTER) (NULL-POINTER))
                (args:
                #S(EAZY-OPENCL.BINDINGS:BOXED-COMMAND-QUEUE
                   :VALUE 140737026928464)
                #S(EAZY-OPENCL.BINDINGS:BOXED-KERNEL :VALUE 140737019923680) 1
                #.(SB-SYS:INT-SAP #X00000000) #.(SB-SYS:INT-SAP #X7FFFE47374D0)
                #.(SB-SYS:INT-SAP #X00000000) 0 #.(SB-SYS:INT-SAP #X00000000)
                #.(SB-SYS:INT-SAP #X00000000) )
OpenCL Success: :SUCCESS for
                (ENQUEUE-READ-BUFFER CQ OUT-DEVICE TRUE 0 SIZE OUT-HOST 0
                                     (NULL-POINTER) (NULL-POINTER))
                (args:
                #S(EAZY-OPENCL.BINDINGS:BOXED-COMMAND-QUEUE
                   :VALUE 140737026928464)
                #S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER :VALUE 140737019907552) 1
                0 13 #.(SB-SYS:INT-SAP #X7FFFF0627FE8) 0
                #.(SB-SYS:INT-SAP #X00000000) #.(SB-SYS:INT-SAP #X00000000) )
"Hello, World" .
OpenCL Success: #S(EAZY-OPENCL.BINDINGS:BOXED-CONTEXT :VALUE 140737025551824)
                for (CREATE-CONTEXT-FROM-TYPE TYPE CONTEXT-PLATFORM PID) (args:
                :DEVICE-TYPE-CPU :CONTEXT-PLATFORM 140737152780544 ).
WARNING:
   This interface is deprecated in opencl 2.0! Use create-command-queue-with-properties.

OpenCL Success: #S(EAZY-OPENCL.BINDINGS:BOXED-COMMAND-QUEUE
                   :VALUE 140737025483536)
                for (CREATE-COMMAND-QUEUE CTX DID) (args:
                #S(EAZY-OPENCL.BINDINGS:BOXED-CONTEXT :VALUE 140737025551824)
                #S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID :VALUE 140737018676832)
                )
OpenCL Success: :SUCCESS for
                (ENQUEUE-ND-RANGE-KERNEL CQ KERNEL 1 (NULL-POINTER)
                                         GLOBAL-WORK-SIZE (NULL-POINTER) 0
                                         (NULL-POINTER) (NULL-POINTER))
                (args:
                #S(EAZY-OPENCL.BINDINGS:BOXED-COMMAND-QUEUE
                   :VALUE 140737025483536)
                #S(EAZY-OPENCL.BINDINGS:BOXED-KERNEL :VALUE 140737025482096) 1
                #.(SB-SYS:INT-SAP #X00000000) #.(SB-SYS:INT-SAP #X7FFFE442E3F0)
                #.(SB-SYS:INT-SAP #X00000000) 0 #.(SB-SYS:INT-SAP #X00000000)
                #.(SB-SYS:INT-SAP #X00000000) )
OpenCL Success: :SUCCESS for
                (ENQUEUE-READ-BUFFER CQ OUT-DEVICE TRUE 0 SIZE OUT-HOST 0
                                     (NULL-POINTER) (NULL-POINTER))
                (args:
                #S(EAZY-OPENCL.BINDINGS:BOXED-COMMAND-QUEUE
                   :VALUE 140737025483536)
                #S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER :VALUE 140737079369728) 1
                0 13 #.(SB-SYS:INT-SAP #X7FFFF0627FE8) 0
                #.(SB-SYS:INT-SAP #X00000000) #.(SB-SYS:INT-SAP #X00000000) )
"Hello, World" .
OpenCL Error:   :INVALID-DEVICE-QUEUE for
                (CREATE-CONTEXT-FROM-TYPE TYPE CONTEXT-PLATFORM PID) (args:
                :DEVICE-TYPE-CUSTOM :CONTEXT-PLATFORM 140737152780544 )ss
OpenCL Success: #S(EAZY-OPENCL.BINDINGS:BOXED-CONTEXT :VALUE 140737025696144)
                for (CREATE-CONTEXT-FROM-TYPE TYPE CONTEXT-PLATFORM PID) (args:
                :DEVICE-TYPE-DEFAULT :CONTEXT-PLATFORM 140737152780544 ).
WARNING:
   This interface is deprecated in opencl 2.0! Use create-command-queue-with-properties.

OpenCL Success: #S(EAZY-OPENCL.BINDINGS:BOXED-COMMAND-QUEUE
                   :VALUE 140737019276400)
                for (CREATE-COMMAND-QUEUE CTX DID) (args:
                #S(EAZY-OPENCL.BINDINGS:BOXED-CONTEXT :VALUE 140737025696144)
                #S(EAZY-OPENCL.BINDINGS:BOXED-DEVICE-ID :VALUE 140737018676832)
                )
OpenCL Success: :SUCCESS for
                (ENQUEUE-ND-RANGE-KERNEL CQ KERNEL 1 (NULL-POINTER)
                                         GLOBAL-WORK-SIZE (NULL-POINTER) 0
                                         (NULL-POINTER) (NULL-POINTER))
                (args:
                #S(EAZY-OPENCL.BINDINGS:BOXED-COMMAND-QUEUE
                   :VALUE 140737019276400)
                #S(EAZY-OPENCL.BINDINGS:BOXED-KERNEL :VALUE 140737025512800) 1
                #.(SB-SYS:INT-SAP #X00000000) #.(SB-SYS:INT-SAP #X7FFFE7E00610)
                #.(SB-SYS:INT-SAP #X00000000) 0 #.(SB-SYS:INT-SAP #X00000000)
                #.(SB-SYS:INT-SAP #X00000000) )
OpenCL Success: :SUCCESS for
                (ENQUEUE-READ-BUFFER CQ OUT-DEVICE TRUE 0 SIZE OUT-HOST 0
                                     (NULL-POINTER) (NULL-POINTER))
                (args:
                #S(EAZY-OPENCL.BINDINGS:BOXED-COMMAND-QUEUE
                   :VALUE 140737019276400)
                #S(EAZY-OPENCL.BINDINGS:BOXED-BUFFER :VALUE 140737025512576) 1
                0 13 #.(SB-SYS:INT-SAP #X7FFFF0627FE8) 0
                #.(SB-SYS:INT-SAP #X00000000) #.(SB-SYS:INT-SAP #X00000000) )
"Hello, World" .
OpenCL Error:   :INVALID-DEVICE-QUEUE for
                (CREATE-CONTEXT-FROM-TYPE TYPE CONTEXT-PLATFORM PID) (args:
                :DEVICE-TYPE-GPU :CONTEXT-PLATFORM 140737152780544 )ss
 Did 42 checks.
    Pass: 36 (85%)
    Skip: 4 ( 9%)
    Fail: 2 ( 4%)

 Failure Details:
 --------------------------------
 HELLOWORLD []: 
      Unexpected Error: #<TYPE-ERROR expected-type: (UNSIGNED-BYTE 32) datum: -1>
The value -1 is not of type (UNSIGNED-BYTE 32)...
 --------------------------------
 --------------------------------
 SETUP []: 
      Unexpected Error: #<TYPE-ERROR expected-type: (UNSIGNED-BYTE 32) datum: -1>
The value -1 is not of type (UNSIGNED-BYTE 32)...
 --------------------------------

 Skip Details:
 HELLOWORLD []: 
     No context found for the device type DEVICE-TYPE-ACCELERATOR in platform 140737152780544.
 HELLOWORLD-FROM-FILE []: 
     No context found for the device type DEVICE-TYPE-GPU in platform 140737152780544.
 HELLOWORLD-FROM-FILE []: 
     No context found for the device type DEVICE-TYPE-CUSTOM in platform 140737152780544.
 HELLOWORLD-FROM-FILE []: 
     No context found for the device type DEVICE-TYPE-ACCELERATOR in platform 140737152780544.

T
```
